### PR TITLE
Update .gitignore to ignore node_modules

### DIFF
--- a/apis/userprofile/.gitignore
+++ b/apis/userprofile/.gitignore
@@ -3,3 +3,4 @@ coverage
 .nyc_output
 reports
 reports-tmp
+node_modules


### PR DESCRIPTION
I think that this should have been in here by default.